### PR TITLE
Rychlé přesměrování na pozvánkové URL Slacku

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,23 +2,10 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Česko.Digital Slack</title>
-    <script type="text/javascript" src="//downloads.mailchimp.com/js/signup-forms/popup/unique-methods/embed.js" data-dojo-config="usePlainJson: true, isDebug: false"></script><script type="text/javascript">window.dojoRequire(["mojo/signup-forms/Loader"], function(L) { L.start({"baseUrl":"mc.us20.list-manage.com","uuid":"fce59476e62e0865beeb03e3c","lid":"b955917c6c","uniqueMethods":true}) })</script>
-    <style>
-        body {
-            text-align: center;
-            margin: 50px auto;
-            max-width: 50%;
-        }
-    </style>
+    <meta http-equiv="refresh" content="0; url=https://join.slack.com/t/cesko-digital/shared_invite/zt-6ygukc79-RwoSj8b90rZx1_4P_oJHow" />
 </head>
 <body>
-
-    <h3>Pokud nevidíte tlačítko subscribe</h3>
-    <p>Na této stránce se vám nyní mělo zobrazit okno s výzvou pro přihlášku do Slacku a zanechání emailové adresy, které patří správci mailing-listu Mailchimp.</p>
-    <p>Dostáváme zprávy, že malému procentu z vás se tak neděje. Většinou stačí stránku otevřít v Inkognito/Private okně (Mailchimp cookies se tím ignorují.) Pokud nikde nevidíte tlačítko Subscribe, napište Josefovi na <a href="mailto:josef@cesko.digital">josef@cesko.digital</a> a zbytek už zařídíme.</p>
-
+    <p>Pokud nedojde k automatickému přesměrování, <a href="https://join.slack.com/t/cesko-digital/shared_invite/zt-6ygukc79-RwoSj8b90rZx1_4P_oJHow">klikněte prosím tady</a>.</p>
 </body>
 </html>


### PR DESCRIPTION
Jak jsme se [bavili ve Slacku](https://cesko-digital.slack.com/archives/CSXGU7F0F/p1584348977298200), chtěli bychom momentálně zrychlit a zjednodušit onboarding, takže bychom chtěli přeskočit tenhle úvodní onboardingový formulář a nahradit ho přímo standardní pozvánkou do Slacku.